### PR TITLE
Various compatibility breaking and non breaking changes

### DIFF
--- a/JKMP.Core/JKCore.cs
+++ b/JKMP.Core/JKCore.cs
@@ -25,7 +25,10 @@ namespace JKMP.Core
         /// </summary>
         public SemVersion Version { get; }
         
-        internal static JKCore Instance { get; private set; } = null!;
+        /// <summary>
+        /// Gets the JKCore singleton. It is the base of the Core framework.
+        /// </summary>
+        public static JKCore Instance { get; private set; } = null!;
         
         private readonly Harmony harmony;
 

--- a/JKMP.Core/JKMP.cs
+++ b/JKMP.Core/JKMP.cs
@@ -12,7 +12,7 @@ namespace JKMP.Core
         /// <summary>
         /// Gets the core manager of JKMP which holds all plugins.
         /// </summary>
-        public static JKCore Core { get; private set; } = null!;
+        private static JKCore core = null!;
 
         /// <summary>
         /// Initializes the JKMP framework. Do not call this, it is only public because the game needs to call it.
@@ -32,7 +32,7 @@ namespace JKMP.Core
             
             LogManager.InitializeLogging();
             AssemblyManager.SetupAssemblyResolving(AppDomain.CurrentDomain);
-            Core = new();
+            core = new();
         }
     }
 }

--- a/JKMP.Core/Patches/GameTitleScreenPatches.cs
+++ b/JKMP.Core/Patches/GameTitleScreenPatches.cs
@@ -52,13 +52,20 @@ namespace JKMP.Core.Patches
             }
         }
 
+        private static readonly string VersionName = Assembly.GetExecutingAssembly().GetName().Version.ToString(fieldCount: 3);
+        private static string? logoText;
+
         private static void DrawLogo()
         {
+            if (logoText == null)
+            {
+                int pluginsCount = JKCore.Instance.Plugins.Count;
+                string numPluginsText = $"{pluginsCount} plugin" + (pluginsCount != 1 ? "s" : "");
+                logoText = $"jkmp core v{VersionName} ({numPluginsText} loaded)";
+            }
+            
             Vector2 drawPosition = new Vector2(45, 160);
-            string version = Assembly.GetExecutingAssembly().GetName().Version.ToString(fieldCount: 3);
-            var pluginCount = JKCore.Instance.Plugins.Count;
-            string numPlugins = $"{pluginCount} plugin" + (pluginCount != 1 ? "s" : "");
-            TextHelper.DrawString(JKContentManager.Font.MenuFont, $"jkmp core v{version} ({numPlugins} loaded)", drawPosition, Color.Gold, Vector2.Zero);
+            TextHelper.DrawString(JKContentManager.Font.MenuFont, logoText, drawPosition, Color.Gold, Vector2.Zero);
         }
     }
 }

--- a/JKMP.Core/Plugins/PluginManager.cs
+++ b/JKMP.Core/Plugins/PluginManager.cs
@@ -124,8 +124,8 @@ namespace JKMP.Core.Plugins
                     pluginContainer.ContentRoot = Path.Combine(pluginDirectory, "Content");
                     pluginContainer.ConfigRoot = Path.Combine("JKMP", "Configs", pluginInfo.Name!);
                     pluginContainer.Plugin.Container = pluginContainer;
-                    pluginContainer.Plugin.Configs = new PluginConfigs(pluginContainer.Plugin);
-                    pluginContainer.Plugin.Configs.JsonSerializerSettings = CreateDefaultJsonSerializerSettings();
+                    pluginContainer.Plugin.Configs = new(pluginContainer.Plugin);
+                    pluginContainer.Plugin.Configs.JsonSerializerSettings ??= CreateDefaultJsonSerializerSettings();
                     pluginContainer.Plugin.Input = new(pluginContainer.Plugin);
 
                     loadedPlugins[Path.GetFileName(pluginDirectory).ToLowerInvariant()] = pluginContainer;


### PR DESCRIPTION
- Made the JKMP.Core property private and changed so that JKCore.Instance property has a public getter
- Reduced GC pressure from rendering title screen logo
- Changed so that a plugin's json serializer settings are not overwritten by core if set by the plugin