### PR TITLE
Set target platform to x86

### DIFF
--- a/JKMP.Core/JKMP.Core.csproj
+++ b/JKMP.Core/JKMP.Core.csproj
@@ -10,6 +10,7 @@
         <Nullable>enable</Nullable>
         <LangVersion>9</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PlatformTarget>x86</PlatformTarget>
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="JKMP.Facepunch.Steamworks.Win32" Version="2.5.0" />


### PR DESCRIPTION
Fixes potential runtime problems with 64-bit plugins (which aren't supported due to the game being 32-bit)